### PR TITLE
execution "s3sync" with `--aws-profile` that sls option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,12 +56,14 @@ class ServerlessPlugin {
   syncDirectory() {
     this.getDescribeStacksOutput('WebAppS3BucketOutput').then(s3Bucket => {
       const s3LocalPath = this.serverless.service.custom.s3LocalPath;
-      const args = [
+      const awscliArgs = !this.options['aws-profile']
+                       ? [] : ['--profile', this.options['aws-profile']];
+      const args = awscliArgs.concat([
         's3',
         'sync',
         s3LocalPath,
         `s3://${s3Bucket}/`,
-      ];
+      ]);
       this.serverless.cli.log(args);
       const result = spawnSync('aws', args);
       const stdout = result && result.stdout && result.stdout.toString();


### PR DESCRIPTION
My expect behavior:

```
$ sls syncToS3 --aws-profile=prod
```

Then, above command works `aws s3 sync` with the `prod` aws profile.
